### PR TITLE
Fix GraphQL schema

### DIFF
--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -21,7 +21,7 @@ type Session {
 
 type Message {
   id: ID!
-  message: String!
+  text: String!
   timestamp: Timestamp!
 }
 

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -20,6 +20,7 @@ type Session {
 }
 
 type Message {
+  id: ID!
   message: String!
   timestamp: Timestamp!
 }

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -28,5 +28,5 @@ type Message {
 
 type Timestamp {
   # Timestamp in ISO format
-  Timestamp: String!
+  timestamp: String!
 }

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -37,7 +37,7 @@ class Session:
 @strawberry.type
 class Message:
     id: strawberry.ID
-    message: str
+    text: str
     timestamp: "Timestamp"
 
 

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -46,7 +46,7 @@ class Message:
 @strawberry.type
 class Timestamp:
     # Timestamp in ISO format
-    Timestamp: datetime.time
+    timestamp: datetime.time
 
 
 schema = strawberry.Schema(Query, Mutation, Subscription)

--- a/backend/schema.py
+++ b/backend/schema.py
@@ -36,6 +36,7 @@ class Session:
 
 @strawberry.type
 class Message:
+    id: strawberry.ID
     message: str
     timestamp: "Timestamp"
 

--- a/frontend/src/session/Session/useSession.tsx
+++ b/frontend/src/session/Session/useSession.tsx
@@ -9,7 +9,7 @@ const SESSION_QUERY = gql`
       messages {
         message
         timestamp {
-          Timestamp
+          timestamp
         }
       }
     }
@@ -25,7 +25,7 @@ const MESSAGE_SUBSCRIPTION = gql`
     message: watchSession(id: $id) {
       message
       timestamp {
-        Timestamp
+        timestamp
       }
     }
   }
@@ -57,7 +57,7 @@ export interface Session extends SessionInfo {
 }
 
 const processMessage = (
-  { message, timestamp: { Timestamp: timestamp } }: RawMessage,
+  { message, timestamp: { timestamp } }: RawMessage,
   index: number
 ): Message => ({
   id: String(index),

--- a/frontend/src/session/Session/useSession.tsx
+++ b/frontend/src/session/Session/useSession.tsx
@@ -7,6 +7,7 @@ const SESSION_QUERY = gql`
     session(id: $id) {
       name
       messages {
+        id
         message
         timestamp {
           timestamp
@@ -23,6 +24,7 @@ interface SessionQueryResult {
 const MESSAGE_SUBSCRIPTION = gql`
   subscription ($id: ID!) {
     message: watchSession(id: $id) {
+      id
       message
       timestamp {
         timestamp
@@ -56,11 +58,12 @@ export interface Session extends SessionInfo {
   removeRecentMessage(message: Message): void;
 }
 
-const processMessage = (
-  { message, timestamp: { timestamp } }: RawMessage,
-  index: number
-): Message => ({
-  id: String(index),
+const processMessage = ({
+  id,
+  message,
+  timestamp: { timestamp },
+}: RawMessage): Message => ({
+  id,
   message,
   timestamp: new Date(timestamp),
 });
@@ -95,7 +98,7 @@ const useWatchSession = (id: string): Session | null => {
         throw error;
       }
 
-      const message = processMessage(data!.message, messages.length);
+      const message = processMessage(data!.message);
       setRecentMessages(new Set([...recentMessages, message]));
       setMessages([...messages, message]);
     },

--- a/frontend/src/session/Session/useSession.tsx
+++ b/frontend/src/session/Session/useSession.tsx
@@ -8,7 +8,7 @@ const SESSION_QUERY = gql`
       name
       messages {
         id
-        message
+        text
         timestamp {
           timestamp
         }
@@ -25,7 +25,7 @@ const MESSAGE_SUBSCRIPTION = gql`
   subscription ($id: ID!) {
     message: watchSession(id: $id) {
       id
-      message
+      text
       timestamp {
         timestamp
       }
@@ -43,7 +43,7 @@ interface Variables {
 
 export interface Message {
   id: string;
-  message: string;
+  text: string;
   timestamp: Date;
 }
 
@@ -60,11 +60,11 @@ export interface Session extends SessionInfo {
 
 const processMessage = ({
   id,
-  message,
+  text,
   timestamp: { timestamp },
 }: RawMessage): Message => ({
   id,
-  message,
+  text,
   timestamp: new Date(timestamp),
 });
 

--- a/frontend/src/session/SessionView/Message/index.tsx
+++ b/frontend/src/session/SessionView/Message/index.tsx
@@ -19,7 +19,7 @@ const Message = ({ message, isRecent, onDated }: Props) => {
         className={classNames(`message_text`, { "-recent": isRecent })}
         onAnimationEnd={onDated}
       >
-        {message.message}
+        {message.text}
       </p>
       <p className="message_age">{age}</p>
     </li>

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -7,7 +7,7 @@ export interface Session {
 
 export interface Message {
   id: string;
-  message: string;
+  text: string;
   timestamp: Timestamp;
 }
 

--- a/frontend/src/types.tsx
+++ b/frontend/src/types.tsx
@@ -12,5 +12,5 @@ export interface Message {
 }
 
 export interface Timestamp {
-  Timestamp: string;
+  timestamp: string;
 }


### PR DESCRIPTION
This PR:

- Fixes bad casing of the field `Timestamp`;
- Adds a new field `id` to `Message`;
- Renames `Message`'s `message` field to `text`.